### PR TITLE
Fix color issue with commandline examples

### DIFF
--- a/content/sdk/quickstarts/cpp/keygendistributed/index.md
+++ b/content/sdk/quickstarts/cpp/keygendistributed/index.md
@@ -43,25 +43,25 @@ Mac users will need to allow use of the library in the Security & Privacy settin
 ## Build
 To change to the KeyGenDistributed folder:
     
-    cd KeyGenDistributed
+    {{< commandline text="cd KeyGenDistributed" >}}
 
 To make a (debug) build:
     
-    ./build.sh --build_type=Debug
+    {{< commandline text="./build.sh --build_type=Debug" >}}
 
 To find the build folder (if it built successfully):
 
 *For linux/mac*
         
-    ls -d build
+    {{< commandline text="ls -d build" >}}
     
 *For windows*
 
-    ls -d build/Debug/
+    {{< commandline text="ls -d build/Debug/" >}}
 
 To see more build options:
     
-    ./build.sh --help
+    {{< commandline text="./build.sh --help" >}}
 
 ## Run
 ### Run as Alice
@@ -69,32 +69,32 @@ To change to the KeyGenDistributed build folder:
 
 *For linux/mac*
     
-    cd KeyGenDistributed/build
+    {{< commandline text="cd KeyGenDistributed/build" >}}
 
 *for windows*
 
-    cd KeyGenDistributed/build/Debug
+    {{< commandline text="cd KeyGenDistributed/build/Debug" >}}
 
  
 To run as Alice:
 
-    ./KeyGenDistributed --user=alice --token=${QRYPT_TOKEN} --key-type=aes --metadata-filename=metadata.bin
+    {{< commandline text="./KeyGenDistributed --user=alice --token=${QRYPT_TOKEN} --key-type=aes --metadata-filename=metadata.bin" >}}
  
 ### Run as Bob
 To change to the KeyGenDistributed build folder:
 
 *For linux/mac*
     
-    cd KeyGenDistributed/build
+    {{< commandline text="cd KeyGenDistributed/build" >}}
 
 *for windows*
 
-    cd KeyGenDistributed/build/Debug
+    {{< commandline text="cd KeyGenDistributed/build/Debug" >}}
 
  
 To run as Alice:
 
-    ./KeyGenDistributed --user=bob --token=${QRYPT_TOKEN} --metadata-filename=metadata.bin
+    {{< commandline text="./KeyGenDistributed --user=bob --token=${QRYPT_TOKEN} --metadata-filename=metadata.bin" >}}
 
 ## Debug
 If you open the folder KeyGenDistributed In Visual Studio Code, you will find debug setups for running as Alice and Bob.

--- a/content/sdk/quickstarts/cpp/keygenlocal/index.md
+++ b/content/sdk/quickstarts/cpp/keygenlocal/index.md
@@ -46,41 +46,41 @@ Mac users will need to allow use of the library in the Security & Privacy settin
 ## Build
 To change to the KeyGenLocal folder:
     
-    cd KeyGenLocal
+    {{< commandline text="cd KeyGenLocal" >}}
 
 To make a (debug) build:
     
-    ./build.sh --build_type=Debug
+    {{< commandline text="./build.sh --build_type=Debug" >}}
 
 To find the build folder (if it built successfully):
 
 *For linux/mac*
-        
-    ls -d build
+    
+    {{< commandline text="ls -d build" >}}
     
 *For windows*
 
-    ls -d build/Debug/
+    {{< commandline text="ls -d build/Debug/" >}}
 
 To see more build options:
     
-    ./build.sh --help
+    {{< commandline text="./build.sh --help" >}}
 
 ## Run
 To change to the KeyGenLocal build folder:
 
 *For linux/mac*
     
-    cd KeyGenLocal/build
+    {{< commandline text="cd KeyGenLocal/build" >}}
 
 *for windows*
 
-    cd KeyGenLocal/build/Debug
+    {{< commandline text="cd KeyGenLocal/build/Debug" >}}
 
 
 To create and dspaly the locally generated AES key:
 
-    ./KeyGenLocal --token=${QRYPT_TOKEN}
+    {{< commandline text="./KeyGenLocal --token=${QRYPT_TOKEN}" >}}
  
 ## Debug
 If you open the folder KeyGenLocal In Visual Studio Code, you will find a debug setup for KeyGenLocal.

--- a/docs/404.html
+++ b/docs/404.html
@@ -9,15 +9,15 @@
   <title>404 Page not found</title>
 
    
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-      <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+      <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
 <style>
     :root #header + #content > #left > #rlblock_left {

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -12,22 +12,22 @@
     <title>Categories :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1031,19 +1031,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/css/theme-mine.css
+++ b/docs/css/theme-mine.css
@@ -81,6 +81,11 @@ code {
     font-family: "IBM Plex Sans", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
 }
 
+#commandline span{
+    color: #abb2bf;
+    font-style: normal;
+}
+
 a {
     color: var(--MAIN-LINK-color);
 }

--- a/docs/data_at_rest/concepts/index.html
+++ b/docs/data_at_rest/concepts/index.html
@@ -12,22 +12,22 @@
     <title>Concepts :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1048,19 +1048,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/data_at_rest/concepts/otp/index.html
+++ b/docs/data_at_rest/concepts/otp/index.html
@@ -12,22 +12,22 @@
     <title>One-Time Pad (OTP) :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1423,19 +1423,19 @@ Note that for an adversary to break a SKU, they must break the protocol or primi
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/data_at_rest/index.html
+++ b/docs/data_at_rest/index.html
@@ -12,22 +12,22 @@
     <title>Data at Rest :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1123,19 +1123,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/eaas/faqs/index.html
+++ b/docs/eaas/faqs/index.html
@@ -12,22 +12,22 @@
     <title>Frequently Asked Questions :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1111,19 +1111,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/eaas/index.html
+++ b/docs/eaas/index.html
@@ -12,22 +12,22 @@
     <title>Entropy as a Service :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1272,19 +1272,19 @@ response <span style="color:#f92672">=</span> requests<span style="color:#f92672
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,22 +12,22 @@
     <title>Home :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -989,19 +989,19 @@ Our documentation is written by developers for developers. The goal is to make i
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/api/cpp/index.html
+++ b/docs/sdk/api/cpp/index.html
@@ -12,22 +12,22 @@
     <title>Qrypt SDK for C&#43;&#43; :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1052,19 +1052,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/api/index.html
+++ b/docs/sdk/api/index.html
@@ -12,22 +12,22 @@
     <title>API Reference :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1051,19 +1051,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/concepts/blast-distributed-multiple-endpoints/index.html
+++ b/docs/sdk/concepts/blast-distributed-multiple-endpoints/index.html
@@ -12,22 +12,22 @@
     <title>BLAST Distributed - multiple endpoints :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1081,19 +1081,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/concepts/blast-local/index.html
+++ b/docs/sdk/concepts/blast-local/index.html
@@ -12,22 +12,22 @@
     <title>BLAST Local :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1061,19 +1061,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/concepts/entropy-projection/index.html
+++ b/docs/sdk/concepts/entropy-projection/index.html
@@ -12,22 +12,22 @@
     <title>How to estimate the projected size of entropy? :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1124,19 +1124,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/concepts/index.html
+++ b/docs/sdk/concepts/index.html
@@ -12,22 +12,22 @@
     <title>Concepts :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1053,19 +1053,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/index.html
+++ b/docs/sdk/index.html
@@ -12,22 +12,22 @@
     <title>Key Generation :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1044,19 +1044,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/overview/index.html
+++ b/docs/sdk/overview/index.html
@@ -12,22 +12,22 @@
     <title>Overview :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1086,19 +1086,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/quickstarts/cpp/index.html
+++ b/docs/sdk/quickstarts/cpp/index.html
@@ -12,22 +12,22 @@
     <title>Qrypt SDK for C&#43;&#43; Quickstarts :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1095,19 +1095,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/quickstarts/cpp/keygendistributed/index.html
+++ b/docs/sdk/quickstarts/cpp/keygendistributed/index.html
@@ -12,22 +12,22 @@
     <title>Quickstart: Distributed Key Generation :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -761,43 +761,43 @@
 <a href="https://support.apple.com/en-us/HT202491" target="_blank" rel="noopener noreferrer">https://support.apple.com/en-us/HT202491</a>
 <h2 id="build">Build</h2>
 <p>To change to the KeyGenDistributed folder:</p>
-<pre><code>cd KeyGenDistributed
+<pre><code><span id="commandline">cd KeyGenDistributed</span>
 </code></pre>
 <p>To make a (debug) build:</p>
-<pre><code>./build.sh --build_type=Debug
+<pre><code><span id="commandline">./build.sh --build_type=Debug</span>
 </code></pre>
 <p>To find the build folder (if it built successfully):</p>
 <p><em>For linux/mac</em></p>
-<pre><code>ls -d build
+<pre><code><span id="commandline">ls -d build</span>
 </code></pre>
 <p><em>For windows</em></p>
-<pre><code>ls -d build/Debug/
+<pre><code><span id="commandline">ls -d build/Debug/</span>
 </code></pre>
 <p>To see more build options:</p>
-<pre><code>./build.sh --help
+<pre><code><span id="commandline">./build.sh --help</span>
 </code></pre>
 <h2 id="run">Run</h2>
 <h3 id="run-as-alice">Run as Alice</h3>
 <p>To change to the KeyGenDistributed build folder:</p>
 <p><em>For linux/mac</em></p>
-<pre><code>cd KeyGenDistributed/build
+<pre><code><span id="commandline">cd KeyGenDistributed/build</span>
 </code></pre>
 <p><em>for windows</em></p>
-<pre><code>cd KeyGenDistributed/build/Debug
+<pre><code><span id="commandline">cd KeyGenDistributed/build/Debug</span>
 </code></pre>
 <p>To run as Alice:</p>
-<pre><code>./KeyGenDistributed --user=alice --token=${QRYPT_TOKEN} --key-type=aes --metadata-filename=metadata.bin
+<pre><code><span id="commandline">./KeyGenDistributed --user=alice --token=${QRYPT_TOKEN} --key-type=aes --metadata-filename=metadata.bin</span>
 </code></pre>
 <h3 id="run-as-bob">Run as Bob</h3>
 <p>To change to the KeyGenDistributed build folder:</p>
 <p><em>For linux/mac</em></p>
-<pre><code>cd KeyGenDistributed/build
+<pre><code><span id="commandline">cd KeyGenDistributed/build</span>
 </code></pre>
 <p><em>for windows</em></p>
-<pre><code>cd KeyGenDistributed/build/Debug
+<pre><code><span id="commandline">cd KeyGenDistributed/build/Debug</span>
 </code></pre>
 <p>To run as Alice:</p>
-<pre><code>./KeyGenDistributed --user=bob --token=${QRYPT_TOKEN} --metadata-filename=metadata.bin
+<pre><code><span id="commandline">./KeyGenDistributed --user=bob --token=${QRYPT_TOKEN} --metadata-filename=metadata.bin</span>
 </code></pre>
 <h2 id="debug">Debug</h2>
 <p>If you open the folder KeyGenDistributed In Visual Studio Code, you will find debug setups for running as Alice and Bob.</p>
@@ -1147,19 +1147,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/quickstarts/cpp/keygenlocal/index.html
+++ b/docs/sdk/quickstarts/cpp/keygenlocal/index.html
@@ -12,22 +12,22 @@
     <title>Quickstart: Local Key Generation :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -751,31 +751,31 @@
 <a href="https://support.apple.com/en-us/HT202491" target="_blank" rel="noopener noreferrer">https://support.apple.com/en-us/HT202491</a>
 <h2 id="build">Build</h2>
 <p>To change to the KeyGenLocal folder:</p>
-<pre><code>cd KeyGenLocal
+<pre><code><span id="commandline">cd KeyGenLocal</span>
 </code></pre>
 <p>To make a (debug) build:</p>
-<pre><code>./build.sh --build_type=Debug
+<pre><code><span id="commandline">./build.sh --build_type=Debug</span>
 </code></pre>
 <p>To find the build folder (if it built successfully):</p>
 <p><em>For linux/mac</em></p>
-<pre><code>ls -d build
+<pre><code><span id="commandline">ls -d build</span>
 </code></pre>
 <p><em>For windows</em></p>
-<pre><code>ls -d build/Debug/
+<pre><code><span id="commandline">ls -d build/Debug/</span>
 </code></pre>
 <p>To see more build options:</p>
-<pre><code>./build.sh --help
+<pre><code><span id="commandline">./build.sh --help</span>
 </code></pre>
 <h2 id="run">Run</h2>
 <p>To change to the KeyGenLocal build folder:</p>
 <p><em>For linux/mac</em></p>
-<pre><code>cd KeyGenLocal/build
+<pre><code><span id="commandline">cd KeyGenLocal/build</span>
 </code></pre>
 <p><em>for windows</em></p>
-<pre><code>cd KeyGenLocal/build/Debug
+<pre><code><span id="commandline">cd KeyGenLocal/build/Debug</span>
 </code></pre>
 <p>To create and dspaly the locally generated AES key:</p>
-<pre><code>./KeyGenLocal --token=${QRYPT_TOKEN}
+<pre><code><span id="commandline">./KeyGenLocal --token=${QRYPT_TOKEN}</span>
 </code></pre>
 <h2 id="debug">Debug</h2>
 <p>If you open the folder KeyGenLocal In Visual Studio Code, you will find a debug setup for KeyGenLocal.</p>
@@ -1128,19 +1128,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/sdk/quickstarts/index.html
+++ b/docs/sdk/quickstarts/index.html
@@ -12,22 +12,22 @@
     <title>Quickstarts :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1051,19 +1051,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -12,22 +12,22 @@
     <title>Tags :: Qrypt</title>
 
     
-    <link href="/css/nucleus.css?1646749006" rel="stylesheet">
-    <link href="/css/fontawesome-all.min.css?1646749006" rel="stylesheet">
-    <link href="/css/hybrid.css?1646749006" rel="stylesheet">
-    <link href="/css/featherlight.min.css?1646749006" rel="stylesheet">
-    <link href="/css/perfect-scrollbar.min.css?1646749006" rel="stylesheet">
-    <link href="/css/auto-complete.css?1646749006" rel="stylesheet">
-    <link href="/css/atom-one-dark-reasonable.css?1646749006" rel="stylesheet">
-    <link href="/css/theme.css?1646749006" rel="stylesheet">
-    <link href="/css/tabs.css?1646749006" rel="stylesheet">
-    <link href="/css/hugo-theme.css?1646749006" rel="stylesheet">
+    <link href="/css/nucleus.css?1646766536" rel="stylesheet">
+    <link href="/css/fontawesome-all.min.css?1646766536" rel="stylesheet">
+    <link href="/css/hybrid.css?1646766536" rel="stylesheet">
+    <link href="/css/featherlight.min.css?1646766536" rel="stylesheet">
+    <link href="/css/perfect-scrollbar.min.css?1646766536" rel="stylesheet">
+    <link href="/css/auto-complete.css?1646766536" rel="stylesheet">
+    <link href="/css/atom-one-dark-reasonable.css?1646766536" rel="stylesheet">
+    <link href="/css/theme.css?1646766536" rel="stylesheet">
+    <link href="/css/tabs.css?1646766536" rel="stylesheet">
+    <link href="/css/hugo-theme.css?1646766536" rel="stylesheet">
     
-    <link href="/css/theme-mine.css?1646749006" rel="stylesheet">
+    <link href="/css/theme-mine.css?1646766536" rel="stylesheet">
     
     
 
-    <script src="/js/jquery-3.3.1.min.js?1646749006"></script>
+    <script src="/js/jquery-3.3.1.min.js?1646766536"></script>
 
     <style>
       :root #header + #content > #left > #rlblock_left{
@@ -53,14 +53,14 @@
     <span data-search-clear=""><i class="fas fa-times"></i></span>
 </div>
 
-<script type="text/javascript" src="/js/lunr.min.js?1646749006"></script>
-<script type="text/javascript" src="/js/auto-complete.js?1646749006"></script>
+<script type="text/javascript" src="/js/lunr.min.js?1646766536"></script>
+<script type="text/javascript" src="/js/auto-complete.js?1646766536"></script>
 <script type="text/javascript">
     
         var baseurl = "https:\/\/QryptInc.github.io";
     
 </script>
-<script type="text/javascript" src="/js/search.js?1646749006"></script>
+<script type="text/javascript" src="/js/search.js?1646766536"></script>
 
     
   </div>
@@ -1031,19 +1031,19 @@
     <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">
       <div style="border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;"></div>
     </div>
-    <script src="/js/clipboard.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.min.js?1646749006"></script>
-    <script src="/js/perfect-scrollbar.jquery.min.js?1646749006"></script>
-    <script src="/js/jquery.sticky.js?1646749006"></script>
-    <script src="/js/featherlight.min.js?1646749006"></script>
-    <script src="/js/highlight.pack.js?1646749006"></script>
+    <script src="/js/clipboard.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.min.js?1646766536"></script>
+    <script src="/js/perfect-scrollbar.jquery.min.js?1646766536"></script>
+    <script src="/js/jquery.sticky.js?1646766536"></script>
+    <script src="/js/featherlight.min.js?1646766536"></script>
+    <script src="/js/highlight.pack.js?1646766536"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script src="/js/modernizr.custom-3.6.0.js?1646749006"></script>
-    <script src="/js/learn.js?1646749006"></script>
-    <script src="/js/hugo-learn.js?1646749006"></script>
+    <script src="/js/modernizr.custom-3.6.0.js?1646766536"></script>
+    <script src="/js/learn.js?1646766536"></script>
+    <script src="/js/hugo-learn.js?1646766536"></script>
     
         
-            <script src="/mermaid/mermaid.js?1646749006"></script>
+            <script src="/mermaid/mermaid.js?1646766536"></script>
         
         <script>
             mermaid.initialize({ startOnLoad: true });

--- a/layouts/shortcodes/commandline.html
+++ b/layouts/shortcodes/commandline.html
@@ -1,0 +1,1 @@
+<span id="commandline">{{ .Get "text"}}</span>

--- a/static/css/theme-mine.css
+++ b/static/css/theme-mine.css
@@ -81,6 +81,11 @@ code {
     font-family: "IBM Plex Sans", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
 }
 
+#commandline span{
+    color: #abb2bf;
+    font-style: normal;
+}
+
 a {
     color: var(--MAIN-LINK-color);
 }


### PR DESCRIPTION
Hugo was interpreting our command line examples as code and coloring them. This fixes it.

command line examples are in:
content/sdk/quickstarts/cpp/keygendistributed/index.md
content/sdk/quickstarts/cpp/keygenlocal/index.md

Had to create a new shortcode to make this work:
layouts/shortcodes/commandline.html

Along with some CSS to override the color attributes:
static/css/theme-mine.css
