### PR TITLE
bugfix/remove link from image

### DIFF
--- a/content/concepts/key-generation-architecture/_index.md
+++ b/content/concepts/key-generation-architecture/_index.md
@@ -16,6 +16,8 @@ Qrypt is the only company that enables encryption without distributing encryptio
 
 {{< figure src="images/blast_1.svg" >}}
 
+---
+
 **Walk-through**
 
 1. Client A determines the key generation requirements: BLAST servers to be used, the sampling seeds, and extraction parameters​

--- a/content/concepts/key-generation-architecture/_index.md
+++ b/content/concepts/key-generation-architecture/_index.md
@@ -15,7 +15,6 @@ Qrypt is the only company that enables encryption without distributing encryptio
 4. No dedicated channels or infrastructure required – unlike quantum key distribution (QKD).
 
 {{< figure src="images/blast_1.svg" >}}
----
 
 **Walk-through**
 


### PR DESCRIPTION
- deleted `##` in markdown that was puting the image in h2 html tag which hugo references as a link to a section in the docs so it was showing clipboard copy icon on hover